### PR TITLE
Fix: Slurm provider supports long GroupBy/Show paths

### DIFF
--- a/providers/Slurm/provider.py
+++ b/providers/Slurm/provider.py
@@ -87,7 +87,10 @@ class SlurmProvider(ObjectProvider):
             return self.get_root_objects_payload()
 
         def list_for_base(base: str) -> List[ProviderObject]:
-            part = base
+            # base may be e.g. 'partition' or 'partition/otherstuff', always use first segment as partition
+            part = base.strip("/").split("/")[0] if base.strip("/") else base.strip("/")
+            if not part:
+                return []
             icon_name = f"./resources/{JOB_ICON_PATH.name}"
             typed: List[ProviderObject] = []
             for jid, user, nodes, state in _get_jobs_and_users_for_partition(part):

--- a/providers/Slurm/provider.py
+++ b/providers/Slurm/provider.py
@@ -86,9 +86,11 @@ class SlurmProvider(ObjectProvider):
         if path_str.strip() == "/" or path_str.strip() == "":
             return self.get_root_objects_payload()
 
+
         def list_for_base(base: str) -> List[ProviderObject]:
-            # base may be e.g. 'partition' or 'partition/otherstuff', always use first segment as partition
-            part = base.strip("/").split("/")[0] if base.strip("/") else base.strip("/")
+            # Always extract the partition as the first segment, ignoring any command tokens
+            segments = base.strip("/").split("/")
+            part = segments[0] if segments else ""
             if not part:
                 return []
             icon_name = f"./resources/{JOB_ICON_PATH.name}"


### PR DESCRIPTION
This PR updates the Slurm provider to correctly handle long paths with <GroupBy:...> and <Show:...> command tokens, enabling chained grouping and filtering in the object browser.